### PR TITLE
Escape --check-cfg args created by build script

### DIFF
--- a/src/custom_build.rs
+++ b/src/custom_build.rs
@@ -533,7 +533,8 @@ pub fn add_custom_flags(
             if i == 0 {
                 cmd = cmd.arg("-Zunstable-options");
             }
-            cmd.arg("--check-cfg").arg(cfg.as_str())
+            cmd.arg("--check-cfg")
+                .arg(escape(cfg.as_str()).into_owned())
         });
 
     let cmd = output


### PR DESCRIPTION
Without this escape all projects that transitively utilize the check-cfg feature (mainly by specifying `cargo:rustc-check-cfg` in a `build.rs`) produce a broken `build.ninja`.

This is a really cool project by the way, very happy to have found it. I am using it to see if I can get the Android Gradle Plugin to build my rust code[^1] :)

[^1]: https://developer.android.com/build/cxx-ninja